### PR TITLE
fix: resolve infinite loop bug affecting channel requests from source

### DIFF
--- a/include/DespillAP.h
+++ b/include/DespillAP.h
@@ -46,6 +46,9 @@ class DespillAPIop : public Iop
   // constructor
   DespillAPIop(Node *node);
 
+  // destructor
+  ~DespillAPIop() {}
+
   int minimum_inputs() const { return 4; }
   int maximum_inputs() const { return 4; }
 


### PR DESCRIPTION
- Only request RGB channels from input
- Only process RGB channels
- Output alpha channel is added afterwards
- Simplified _request since only image bounds are needed, not extra bbox
- Simplified foreach to if statement when writing alpha channel to selected output channel